### PR TITLE
feat: Add query parameter to force audio format and quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ In `.env.example` you will find 3 options:
 
 - `/:track_id` get the metadata of the track ID. (JSON)
 - `/:track_id/listen` get the track itself, returns the OGG Vorbis or MP3 stream. (Binary)
+  - Support overriding return format and quality (using query parameter)
+    - `q` parameter to adjust quality (`quality`, `qual`)
+    	- `low` for the lowest quality (`lowest`, `lq`)
+    	- `normal` for the "normal" or "high" quality (`medium`)
+    	- `high` for the highest quality (`highest`, `hq`)
+    - `format` parameter to adjust format (`fmt`)
+    	- `mp3` to force MP3 format
+    	- `aac` to force AAC format (`m4a`)
+    	- `vorbis` to force Vorbis format (`opus`, `ogg`)
 - `/:track_id/lyrics` get the track lyrics (if available) (JSON)
 - `/album/:album_id/` get the list of Album data. (JSON)
 - `/playlist/:playlist_id` get the list of playlist data. (JSON)
@@ -66,6 +75,15 @@ In `.env.example` you will find 3 options:
 - `/artist/:artist_id/` get the list of artist top tracks. (JSON) **[See note at the bottom]**
 - `/episode/:episode_id` get the metadata of a podcast episode. (JSON)
 - `/episode/:episode_id/listen` get the episode itself, returns an OGG Vorbis or MP3 stream. (Binary)
+  - Support overriding return format and quality (using query parameter)
+    - `q` parameter to adjust quality (`quality`, `qual`)
+    	- `low` for the lowest quality (`lowest`, `lq`)
+    	- `normal` for the "normal" or "high" quality (`medium`)
+    	- `high` for the highest quality (`highest`, `hq`)
+    - `format` parameter to adjust format (`fmt`)
+    	- `mp3` to force MP3 format
+    	- `aac` to force AAC format (`m4a`)
+    	- `vorbis` to force Vorbis format (`opus`, `ogg`)
 
 The other API can be used to fetch about playlist/album/track information before requesting lavaplayer the real URL (`/:track_id/listen`).
 

--- a/app.py
+++ b/app.py
@@ -109,7 +109,7 @@ async def index(request: sanic.Request) -> HTTPResponse:
         dedent(
             """
             Now serving...
-            Spotilava v1.1.0
+            Spotilava v1.2.0
 
                 - /<track_id>
                 - /<track_id>/listen

--- a/internals/monke.py
+++ b/internals/monke.py
@@ -51,6 +51,7 @@ def load_track_with_fallback(
     preload: bool,
     halt_listener: HaltListener,
     force_format: Optional[SpotifyAudioFormat] = None,
+    force_quality: bool = False,
 ):
     session: Session = getattr(self, "__session", getattr(self, "_PlayableContentFeeder__session", None))
     if type(track_id_or_track) is TrackId:
@@ -62,7 +63,7 @@ def load_track_with_fallback(
     else:
         track = track_id_or_track
 
-    selected_audio = AutoFallbackAudioQuality(audio_quality, force_format).get_file(track.file)
+    selected_audio = AutoFallbackAudioQuality(audio_quality, force_format, force_quality).get_file(track.file)
     if selected_audio is None:
         self.logger.fatal("Couldn't find any suitable audio file: available: {}".format(track.file))
         raise NoAudioFound
@@ -76,13 +77,14 @@ def load_episode_with_fallback(
     preload: bool,
     halt_listener: HaltListener,
     force_format: Optional[SpotifyAudioFormat] = None,
+    force_quality: bool = False,
 ):
     session: Session = getattr(self, "__session", getattr(self, "_PlayableContentFeeder__session", None))
     episode = session.api().get_metadata_4_episode(episode_id)
     if episode.external_url:
         return CdnFeedHelper.load_episode_external(session, episode, halt_listener)
 
-    selected_audio = AutoFallbackAudioQuality(audio_quality, force_format).get_file(episode.audio)
+    selected_audio = AutoFallbackAudioQuality(audio_quality, force_format, force_quality).get_file(episode.audio)
     if selected_audio is None:
         self.logger.fatal("Couldn't find any suitable audio file: available: {}".format(episode.audio))
         raise NoAudioFound

--- a/internals/monke.py
+++ b/internals/monke.py
@@ -98,11 +98,17 @@ def monkeypatch_load():
         audio_quality: AudioQuality,
         preload: bool,
         halt_listener: HaltListener,
+        force_format: Optional[SpotifyAudioFormat] = None,
+        force_quality: bool = False,
     ):
         if type(playable_id) is TrackId:
-            return load_track_with_fallback(self, playable_id, audio_quality, preload, halt_listener)
+            return load_track_with_fallback(
+                self, playable_id, audio_quality, preload, halt_listener, force_format, force_quality
+            )
         elif type(playable_id) is EpisodeId:
-            return load_episode_with_fallback(self, playable_id, audio_quality, preload, halt_listener)
+            return load_episode_with_fallback(
+                self, playable_id, audio_quality, preload, halt_listener, force_format, force_quality
+            )
         else:
             raise TypeError("Unknown content: {}".format(playable_id))
 

--- a/internals/monke.py
+++ b/internals/monke.py
@@ -66,7 +66,7 @@ def load_track_with_fallback(
     selected_audio = AutoFallbackAudioQuality(audio_quality, force_format, force_quality).get_file(track.file)
     if selected_audio is None:
         self.logger.fatal("Couldn't find any suitable audio file: available: {}".format(track.file))
-        raise NoAudioFound
+        raise NoAudioFound(track.file)
     return self.load_stream(selected_audio, track, None, preload, halt_listener)
 
 
@@ -87,7 +87,7 @@ def load_episode_with_fallback(
     selected_audio = AutoFallbackAudioQuality(audio_quality, force_format, force_quality).get_file(episode.audio)
     if selected_audio is None:
         self.logger.fatal("Couldn't find any suitable audio file: available: {}".format(episode.audio))
-        raise NoAudioFound
+        raise NoAudioFound(episode.file)
     return self.load_stream(selected_audio, None, episode, preload, halt_listener)
 
 

--- a/internals/spotify/client.py
+++ b/internals/spotify/client.py
@@ -252,13 +252,16 @@ class LIBRESpotifyWrapper:
         track_real = TrackId.from_uri(f"spotify:track:{track_id}")
         self.logger.info(f"SpotifyTrack: Fetching track <{track_id}>")
 
-        execute_this = self.session.content_feeder().load
+        extra_kwargs = {
+            "force_quality": force_quality is not None,
+        }
         if force_format is not None:
-            execute_this = functools.partial(execute_this, force_format=force_format)
+            extra_kwargs["force_format"] = force_format
+        EXECUTOR = functools.partial(self.session.content_feeder().load, force_format=force_format)
         try:
             track = await self._loop.run_in_executor(
                 None,
-                execute_this,
+                EXECUTOR,
                 track_real,
                 force_quality or AudioQuality.VERY_HIGH,
                 False,
@@ -299,13 +302,16 @@ class LIBRESpotifyWrapper:
     ):
         episode_real = EpisodeId.from_uri(f"spotify:episode:{episode_id}")
         self.logger.info(f"SpotifyEpisode: Fetching episode <{episode_id}>")
-        execute_this = self.session.content_feeder().load
+        extra_kwargs = {
+            "force_quality": force_quality is not None,
+        }
         if force_format is not None:
-            execute_this = functools.partial(execute_this, force_format=force_format)
+            extra_kwargs["force_format"] = force_format
+        EXECUTOR = functools.partial(self.session.content_feeder().load, force_format=force_format)
         try:
             episode = await self._loop.run_in_executor(
                 None,
-                execute_this,
+                EXECUTOR,
                 episode_real,
                 force_quality or AudioQuality.VERY_HIGH,
                 False,

--- a/internals/spotify/client.py
+++ b/internals/spotify/client.py
@@ -25,6 +25,7 @@ SOFTWARE.
 from __future__ import annotations
 
 import asyncio
+import functools
 import logging
 import os
 from dataclasses import dataclass
@@ -49,6 +50,7 @@ from internals.errors import NoAudioFound, NoTrackFound
 from internals.utils import complex_walk
 
 from .models import *
+from .shims import SpotifyAudioFormat
 
 BASE_DIR = Path(__file__).absolute().parent.parent.parent
 _log = logging.getLogger("Internals.Spotify")
@@ -241,15 +243,24 @@ class LIBRESpotifyWrapper:
         self.logger.info("Spotify: Authenticated")
         self.session = session
 
-    async def get_track(self, track_id: str):
+    async def get_track(
+        self,
+        track_id: str,
+        force_format: Optional[SpotifyAudioFormat] = None,
+        force_quality: Optional[AudioQuality] = None,
+    ):
         track_real = TrackId.from_uri(f"spotify:track:{track_id}")
         self.logger.info(f"SpotifyTrack: Fetching track <{track_id}>")
+
+        execute_this = self.session.content_feeder().load
+        if force_format is not None:
+            execute_this = functools.partial(execute_this, force_format=force_format)
         try:
             track = await self._loop.run_in_executor(
                 None,
-                self.session.content_feeder().load,
+                execute_this,
                 track_real,
-                AudioQuality.VERY_HIGH,
+                force_quality or AudioQuality.VERY_HIGH,
                 False,
                 None,
             )
@@ -280,15 +291,23 @@ class LIBRESpotifyWrapper:
             track_id, track.episode, track.track, init_stream, track.normalization_data, track.metrics, loop=self._loop
         )
 
-    async def get_episode(self, episode_id: str):
+    async def get_episode(
+        self,
+        episode_id: str,
+        force_format: Optional[SpotifyAudioFormat] = None,
+        force_quality: Optional[AudioQuality] = None,
+    ):
         episode_real = EpisodeId.from_uri(f"spotify:episode:{episode_id}")
         self.logger.info(f"SpotifyEpisode: Fetching episode <{episode_id}>")
+        execute_this = self.session.content_feeder().load
+        if force_format is not None:
+            execute_this = functools.partial(execute_this, force_format=force_format)
         try:
             episode = await self._loop.run_in_executor(
                 None,
-                self.session.content_feeder().load,
+                execute_this,
                 episode_real,
-                AudioQuality.VERY_HIGH,
+                force_quality or AudioQuality.VERY_HIGH,
                 False,
                 None,
             )

--- a/internals/spotify/shims.py
+++ b/internals/spotify/shims.py
@@ -1,0 +1,34 @@
+"""
+MIT License
+
+Copyright (c) 2021-present noaione
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+from enum import Enum
+
+__all__ = ("SpotifyAudioFormat",)
+
+
+class SpotifyAudioFormat(Enum):
+    VORBIS = "vorbis"
+    MP3 = "mp3"
+    AAC = "aac"
+    FLAC = "flac"

--- a/internals/spotify/tracks.py
+++ b/internals/spotify/tracks.py
@@ -34,6 +34,8 @@ from librespot.audio import SuperAudioFormat
 from librespot.proto import Metadata_pb2 as Metadata
 from librespot.structure import AudioQualityPicker
 
+from .shims import SpotifyAudioFormat
+
 __all__ = ("AutoFallbackAudioQuality",)
 
 
@@ -82,7 +84,7 @@ class AutoFallbackAudioQuality(AudioQualityPicker):
     logger = logging.getLogger("Spotilava:Player:AutoFallbackAudioQuality")
     preferred: AudioQualityPatched
 
-    def __init__(self, preferred: AudioQualityPatched) -> None:
+    def __init__(self, preferred: AudioQualityPatched, force_format: Optional[SpotifyAudioFormat] = None) -> None:
         self.preferred: AudioQualityPatched = preferred
         if not isinstance(preferred, AudioQualityPatched):
             self.preferred: AudioQualityPatched = AudioQualityPatched.from_super(preferred)
@@ -92,6 +94,8 @@ class AutoFallbackAudioQuality(AudioQualityPicker):
             AudioQualityPatched.NORMAL,
         ]
         self.other_quality.remove(self.preferred)
+
+        self._force_format: Optional[SpotifyAudioFormat] = force_format
 
     @staticmethod
     def get_all_files(files: List[Metadata.AudioFile], format: SuperAudioFormat) -> List[Metadata.AudioFile]:

--- a/routes/_utils.py
+++ b/routes/_utils.py
@@ -1,0 +1,62 @@
+from typing import List, Optional, Union, cast
+
+from librespot.audio.decoders import AudioQuality
+from sanic.request import Request
+
+from internals.spotify.shims import SpotifyAudioFormat
+
+__all__ = (
+    "get_spotify_audio_format",
+    "get_spotify_audio_quality",
+)
+
+
+QueryParam = Optional[Union[str, List[str]]]
+
+
+def select_first(single_or_multi: Union[str, List[str]]) -> str:
+    if isinstance(single_or_multi, list):
+        return single_or_multi[0]
+    return single_or_multi
+
+
+def get_spotify_audio_format(request: Request) -> Optional[SpotifyAudioFormat]:
+    # Fallback from `format` to `fmt`
+    query_param = cast(QueryParam, request.args.get("format") or request.args.get("fmt"))
+    if query_param is None:
+        return None
+    query_param = select_first(query_param)
+
+    query_param = query_param.lower()
+    audio_mappings = {
+        "mp3": SpotifyAudioFormat.MP3,
+        "aac": SpotifyAudioFormat.AAC,
+        "vorbis": SpotifyAudioFormat.VORBIS,
+        "ogg": SpotifyAudioFormat.VORBIS,
+        "m4a": SpotifyAudioFormat.AAC,
+        "opus": SpotifyAudioFormat.VORBIS,
+        "flac": SpotifyAudioFormat.FLAC,
+        "hires": SpotifyAudioFormat.FLAC,
+    }
+
+    return audio_mappings.get(query_param)
+
+
+def get_spotify_audio_quality(request: Request) -> Optional[AudioQuality]:
+    # Fallback from `format` to `fmt`
+    query_param = cast(QueryParam, request.args.get("q") or request.args.get("qual") or request.args.get("quality"))
+    if query_param is None:
+        return None
+
+    query_param = query_param.lower()
+    quality_mappings = {
+        "lowest": AudioQuality.NORMAL,
+        "low": AudioQuality.NORMAL,
+        "medium": AudioQuality.HIGH,
+        "normal": AudioQuality.HIGH,
+        "high": AudioQuality.VERY_HIGH,
+        "hq": AudioQuality.VERY_HIGH,
+        "highest": AudioQuality.VERY_HIGH,
+    }
+
+    return quality_mappings.get(query_param)

--- a/routes/_utils.py
+++ b/routes/_utils.py
@@ -52,6 +52,7 @@ def get_spotify_audio_quality(request: Request) -> Optional[AudioQuality]:
     quality_mappings = {
         "lowest": AudioQuality.NORMAL,
         "low": AudioQuality.NORMAL,
+        "lq": AudioQuality.NORMAL,
         "medium": AudioQuality.HIGH,
         "normal": AudioQuality.HIGH,
         "high": AudioQuality.VERY_HIGH,

--- a/routes/episodes.py
+++ b/routes/episodes.py
@@ -7,6 +7,8 @@ from sanic.response import HTTPResponse, json, raw, text
 from internals.sanic import SpotilavaBlueprint, SpotilavaSanic, stream_response
 from internals.spotify import should_inject_metadata
 
+from ._utils import get_spotify_audio_format, get_spotify_audio_quality
+
 logger = logging.getLogger("Routes.Episodes")
 
 episodes_bp = SpotilavaBlueprint("spotify-episodes", url_prefix="/episode")
@@ -66,7 +68,9 @@ async def get_episode_listen(request: sanic.Request, episode_id: str) -> HTTPRes
         )
         return text("Invalid episode id.", status=400)
 
-    episode_info = await app.spotify.get_episode(episode_id)
+    force_format = get_spotify_audio_format(request)
+    force_quality = get_spotify_audio_quality(request)
+    episode_info = await app.spotify.get_episode(episode_id, force_format, force_quality)
     if episode_info is None:
         logger.warning(f"EpisodeListen: Unable to find episode <{episode_id}>")
         if meth == "head":

--- a/routes/tracks.py
+++ b/routes/tracks.py
@@ -7,6 +7,8 @@ from sanic.response import HTTPResponse, json, raw, text
 from internals.sanic import SpotilavaBlueprint, SpotilavaSanic, stream_response
 from internals.spotify import should_inject_metadata
 
+from ._utils import get_spotify_audio_format, get_spotify_audio_quality
+
 logger = logging.getLogger("Routes.Tracks")
 
 tracks_bp = SpotilavaBlueprint("spotify-tracks", url_prefix="/")
@@ -58,7 +60,9 @@ async def get_track_listen(request: sanic.Request, track_id: str):
         logger.warning(f"TrackListen: Track <{track_id}> is invalid, expected alphanumeric, got {track_id} instead")
         return text("Invalid track id.", status=400)
 
-    find_track = await app.spotify.get_track(track_id)
+    force_format = get_spotify_audio_format(request)
+    force_quality = get_spotify_audio_quality(request)
+    find_track = await app.spotify.get_track(track_id, force_format, force_quality)
     if find_track is None:
         logger.warning(f"TrackListen: Unable to find track <{track_id}>")
         if meth == "head":

--- a/routes/tracks.py
+++ b/routes/tracks.py
@@ -84,6 +84,8 @@ async def get_track_listen(request: sanic.Request, track_id: str):
             end_read = range_search.group("end")
             if end_read is not None:
                 end_read = int(end_read)
+    if end_read is None:
+        end_read = -1
 
     logger.debug(f"TrackListen: Reading first {CHUNK_SIZE} bytes of <{track_id}>")
     first_data = await find_track.read_bytes(CHUNK_SIZE)


### PR DESCRIPTION
Checklist:
- [x] Implemented audio quality/format forcing
- [x] Actually return the proper requested format
- [x] Tested forcing audio quality
- [x] Tested forcing audio format
- [x] Tested forcing both

How to request:
- `q` parameter to adjust quality (`quality`, `qual`)
	- `low` for the lowest quality (`lowest`, `lq`)
	- `normal` for the "normal" or "high" quality (`medium`)
	- `high` for the highest quality (`highest`, `hq`)
- `format` parameter to adjust format (`fmt`)
	- `mp3` to force MP3 format
	- `aac` to force AAC format (`m4a`)
	- `vorbis` to force Vorbis format (`opus`, `ogg`)